### PR TITLE
Implement locally integrated FAQ page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -27,6 +27,7 @@ slackin_url: 'https://slackin-pdf-archiver.herokuapp.com'
 github_url: 'https://github.com/PDF-Archiver/PDF-Archiver'
 faq_url: 'https://github.com/PDF-Archiver/PDF-Archiver/wiki/FAQs'
 support_email: 'support@pdf-archiver.mailclark.ai'
+faq_email: 'faq@pdf-archiver.io'
 feature_requests_email: 'feature-request@pdf-archiver.mailclark.ai'
 
 # Build settings

--- a/_faq/01-what-is-the-basic-workflow.md
+++ b/_faq/01-what-is-the-basic-workflow.md
@@ -1,0 +1,14 @@
+---
+title: What is the basic workflow?
+order: 01
+---
+
+* Start **PDF Archiver**
+* Set archive path in the preferences (`⌘ ,`)
+* Select untagged documents via the *Add PDFs* button or `⌘ o`
+* Set the document attributes on the right
+    * Pick a date
+    * Write a description
+    * Choose tags in the search field and press the return key: `⏎`
+* Save the attributes by pressing the *Save* button or `⌘ s`
+

--- a/_faq/how-can-i-fix-missing-tags.md
+++ b/_faq/how-can-i-fix-missing-tags.md
@@ -1,0 +1,7 @@
+---
+title: How can I fix missing tags?
+---
+
+Click on the Menu Bar in **PDF Archiver**: `Help > Update tags`
+
+This will refresh the available tags by analysing the tags in your archive. Normally, this step should not be necessary. Please consider to open an [issue]({{site.github_url}}/issues) if you have to use this workaround.

--- a/_faq/how-do-i-reset-all-settings.md
+++ b/_faq/how-do-i-reset-all-settings.md
@@ -1,0 +1,6 @@
+---
+title: How do I reset all settings?
+---
+
+* Open the App
+* Select in the Menu Bar: `Help > Reset Settings`

--- a/_faq/how-do-i-zoom-the-preview.md
+++ b/_faq/how-do-i-zoom-the-preview.md
@@ -1,0 +1,6 @@
+---
+title: How do I zoom the preview?
+---
+
+* Use the pinch-to-zoom gesture on your trackpad: <https://support.apple.com/en-us/HT204895>
+* Use the keyboard shortcuts `⌘ +` and `⌘ -`

--- a/_faq/how-to-delete-tags-from-a-document.md
+++ b/_faq/how-to-delete-tags-from-a-document.md
@@ -1,0 +1,6 @@
+---
+title: How to delete tags from a document?
+---
+
+* Select a document in **PDF Archiver**.
+* Click on the tag in the document attributes area, which should be removed.

--- a/_faq/it-is-not-possible-to-save-a-document.md
+++ b/_faq/it-is-not-possible-to-save-a-document.md
@@ -1,0 +1,6 @@
+---
+title: It is not possible to save a document, what can I do?
+---
+
+* Reset the settings: `Help > Reset Settings`
+* Set the archive path again via the preferences: `⌘ ,`

--- a/_faq/what-will-the-archive-structure-look-like.md
+++ b/_faq/what-will-the-archive-structure-look-like.md
@@ -1,0 +1,15 @@
+---
+title: What will the archive structure look like?
+---
+
+```
+.
+└── Archive
+    ├── 2017
+    │   ├── 2017-05-12--apple-macbook__apple_bill.pdf
+    │   └── 2017-01-02--this-is-a-document__bill_vacation.pdf
+    └── 2018
+        ├── 2018-04-30--this-might-be-important__work_travel.pdf
+        ├── 2018-05-26--parov-stelar__concert_ticket.pdf
+        └── 2018-12-01--master-thesis__finally_longterm_university.pdf
+```

--- a/_faq/where-can-i-find-my-documents-after-renaming.md
+++ b/_faq/where-can-i-find-my-documents-after-renaming.md
@@ -1,0 +1,5 @@
+---
+title: Where can I find my documents after the renaming?
+---
+
+All the renamed documents can be found at the path you have specified in the preferences (`⌘ ,`).

--- a/_faq/zz-could-not-find-question.md
+++ b/_faq/zz-could-not-find-question.md
@@ -1,0 +1,6 @@
+---
+title: Could not find your question here?
+---
+
+* Preferred: Get in contact with us on [Slack]({{site.slackin_url}})
+* Alternative: Send an [email](mailto:{{site.faq_email}}?subject=FAQ)

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -8,7 +8,7 @@
           {% t pages.changelog %}</a>
       </li>
       <li class="list-inline-item">
-        <a href="{{ site.faq_url }}">
+        <a href="{% translate_link faq %}">
           {% t pages.faq %}</a>
       </li>
       <li class="list-inline-item">

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -17,3 +17,7 @@ $fa-font-path: "../assets/fonts/font-awesome/";
   margin-top: -3%;
   margin-bottom: -8%;
 }
+
+.faq_question {
+  padding: 20px 0;
+}

--- a/faq.md
+++ b/faq.md
@@ -5,16 +5,13 @@ namespace: faq
 
 layout: page
 permalink:   /faq
-permalink_de:   /faq
 ---
 
-{%- for faq in site.faqs -%}
-<section class="faq_question">
-  {%- assign date_format = site.date_format | default: "%Y-%m-%d" -%}
-  <h2>
-      {% t faq.question %}
-      <small class="text-muted">{{ version.date | date: date_format }}</small>
-  </h2>
-  {% t faq.answer %}
-</section>
+{% assign sorted_faqs = site.faq | sort: 'slug' %}
+
+{%- for faq in sorted_faqs -%}
+  <section class="faq_question">
+    <h2>{{ faq.title }}</h2>
+    {{ faq.content }}
+  </section>
 {%- endfor -%}


### PR DESCRIPTION
This PR shall resolve #5.

It places the current collection of FAQs from the GH wiki of the Archiver in separate `.md` files, setting the questions as the title in the header, and the answer as the file contents.

Sorting the questions on the site is currently done alphabetically via slug field, i.e. the filename. The first question ("What is the basic workflow?") is forcedly placed up top by prefixing the filename with `01-`, while the last one ("Could not find your question here?) is pushed down with prefix `zz-`.

As always usage of variables is encouraged (and already done in the current set of questions/answers), and can be done with using {{site.my_fancy_variable}} as defined in `_config.yml`.

The link to the GH wiki page in the site footer is of course replaced with an internal link.