### PR TITLE
Proper table spacing

### DIFF
--- a/_faq/01-what-is-the-basic-workflow.md
+++ b/_faq/01-what-is-the-basic-workflow.md
@@ -4,11 +4,11 @@ order: 01
 ---
 
 * Start **PDF Archiver**
-* Set archive path in the preferences (`⌘ ,`)
-* Select untagged documents via the *Add PDFs* button or `⌘ o`
+* Set archive path in the preferences (<kbd>⌘ , </kbd>)
+* Select untagged documents via the *Add PDFs* button or <kbd>⌘ o</kbd>
 * Set the document attributes on the right
     * Pick a date
     * Write a description
-    * Choose tags in the search field and press the return key: `⏎`
-* Save the attributes by pressing the *Save* button or `⌘ s`
+    * Choose tags in the search field and press the return key: <kbd>⏎</kbd>
+* Save the attributes by pressing the *Save* button or <kbd>⌘ s</kbd>
 

--- a/_faq/02-keyboard-shortcuts.md
+++ b/_faq/02-keyboard-shortcuts.md
@@ -2,14 +2,14 @@
 title: What shortcuts are available?
 ---
 
-| Keys          | Shortcut                                      |
-|:-------------:| --------------------------------------------- |
-| `↹`          | switch to next field                          |
-| `⌘ ,`        | open the preferences panel                     |
-| `⌘ o`        | add new PDF documents                          |
-| `⌘ s`        | save the current document in your archive      |
-| `⌘ ⌫`        | trash the selected document                   |
-| `⌘ 9`        | zoom to fit                                    |
-| `⌘ 0`        | zoom to original size                          |
-| `⌘ -`        | zoom out                                       |
-| `⌘ +`        | zoom in                                        |
+| Keys          | Shortcut                                        |
+|:-------------:| ---------------------------------------------- |
+|  <kbd> ↹ </kbd>  | switch to next field                        |
+|  <kbd>⌘ ,</kbd>  | open the preferences panel                  |
+|  <kbd>⌘ o</kbd>  | add new PDF documents                       |
+|  <kbd>⌘ s</kbd>  | save the current document in your archive   |
+|  <kbd>⌘ ⌫</kbd>  | trash the selected document                 |
+|  <kbd>⌘ 9</kbd>  | zoom to fit                                 |
+|  <kbd>⌘ 0</kbd>  | zoom to original size                       |
+|  <kbd>⌘ -</kbd>  | zoom out                                    |
+|  <kbd>⌘ +</kbd>  | zoom in                                     |

--- a/_faq/how-do-i-zoom-the-preview.md
+++ b/_faq/how-do-i-zoom-the-preview.md
@@ -3,4 +3,4 @@ title: How do I zoom the preview?
 ---
 
 * Use the pinch-to-zoom gesture on your trackpad: <https://support.apple.com/en-us/HT204895>
-* Use the keyboard shortcuts `⌘ +` and `⌘ -`
+* Use the keyboard shortcuts <kbd>⌘ +</kbd> and <kbd>⌘ -</kbd>

--- a/_faq/it-is-not-possible-to-save-a-document.md
+++ b/_faq/it-is-not-possible-to-save-a-document.md
@@ -3,4 +3,4 @@ title: It is not possible to save a document, what can I do?
 ---
 
 * Reset the settings: `Help > Reset Settings`
-* Set the archive path again via the preferences: `⌘ ,`
+* Set the archive path again via the preferences: <kbd>⌘ ,</kbd>

--- a/_faq/where-can-i-find-my-documents-after-renaming.md
+++ b/_faq/where-can-i-find-my-documents-after-renaming.md
@@ -2,4 +2,4 @@
 title: Where can I find my documents after the renaming?
 ---
 
-All the renamed documents can be found at the path you have specified in the preferences (`⌘ ,`).
+All the renamed documents can be found at the path you have specified in the preferences (<kbd>⌘ ,</kbd>).

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -35,6 +35,7 @@ $simple-line-font-path: $font-path;
        url('#{$font-path}catamaran-v4-latin-200.svg#Catamaran') format('svg'); /* Legacy iOS */
 }
 
+$font-family-monospace: Monaco, Consolas, "Courier New", monospace !default;
 
 @import "bootstrap";
 @import "font-awesome";
@@ -59,5 +60,9 @@ $simple-line-font-path: $font-path;
 
 table {
   @extend .table;
+}
+
+kbd {
+  font-size: 100%;
 }
 

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -56,3 +56,8 @@ $simple-line-font-path: $font-path;
 .faq_question {
   padding: 20px 0;
 }
+
+table {
+  @extend .table;
+}
+


### PR DESCRIPTION
Closing #23: 

* Use BS4 table styling on all `<table>` elements (which are built from MarkDown)
* Convert all `code` blocks for keyboard shortcuts to use the proper HTML markup `<kbd>`
* Override font stack for monospaced elements (i.e. `<kbd>` and others) to improve legibility of symbols like TAB key.

@JulianKahnert In the future you should use `<kbd>…</kbd>` whenever you want to print key commands :)